### PR TITLE
Disable mac builds on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@
 language: julia
 os:
   - linux
-  - osx
 julia:
   - 0.5
 notifications:


### PR DESCRIPTION
They seem to be continually stuck, and I don't really think we have any mac specific things. I'd say we can reenable before we release a version, but for now those builds just seem to slow things down.