### PR TITLE
Fix readme typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,4 @@
 
 ## Overview
 
-This package implements the Microsoft [Language Server Protocoll](https://github.com/Microsoft/language-server-protocol) for the [julia](http://julialang.org/) programming language. The package is currently used by the [julia extension](https://marketplace.visualstudio.com/items?itemName=julialang.language-julia) for [VS Code](https://code.visualstudio.com/).
+This package implements the Microsoft [Language Server Protocol](https://github.com/Microsoft/language-server-protocol) for the [Julia](http://julialang.org/) programming language. The package is currently used by the [Julia extension](https://marketplace.visualstudio.com/items?itemName=julialang.language-julia) for [VS Code](https://code.visualstudio.com/).


### PR DESCRIPTION
I double-checked that Julia is, officially and practically, capitalized when used mid sentence.