### PR TITLE
WIP: Load cache in spawned process

### DIFF
--- a/src/cache.jl
+++ b/src/cache.jl
@@ -95,7 +95,7 @@ updatecache(absentmodule::Symbol, server) = updatecache([absentmodule], server)
 
 function updatecache(absentmodules::Vector{Symbol}, server)
     fname = functionloc(updatecache, Tuple{Symbol, Any})[1]
-    o,i, p = readandwrite(`julia -e "delete!(Base.ENV, \"JULIA_PKGDIR\");
+    o,i, p = readandwrite(`$JULIA_HOME/julia -e "delete!(Base.ENV, \"JULIA_PKGDIR\");
     include(\"$fname\");
     top=Dict();
     for m in [$(join((m->"\"$m\"").(absentmodules),", "))];

--- a/src/cache.jl
+++ b/src/cache.jl
@@ -94,10 +94,24 @@ end
 updatecache(absentmodule::Symbol, server) = updatecache([absentmodule], server)
 
 function updatecache(absentmodules::Vector{Symbol}, server)
-    send(Message(3, "Adding $(join(absentmodules, ", ")) to cache, this may take a minute"), server)    
-    run(`$JULIA_HOME/julia -e "using LanguageServer;delete!(Base.ENV, \"JULIA_PKGDIR\"); top = LanguageServer.loadcache(); for m in [$(join((m->"\"$m\"").(absentmodules),", "))]; LanguageServer.modnames(m, top); end; LanguageServer.savecache(top)"`)
-    server.cache = loadcache()
-    send(Message(3, "Cache stored at $(joinpath(Pkg.dir("LanguageServer"), "cache", "docs.cache"))"), server)
+    fname = functionloc(updatecache, Tuple{Symbol, Any})[1]
+    o,i, p = readandwrite(`julia -e "delete!(Base.ENV, \"JULIA_PKGDIR\");
+    include(\"$fname\");
+    top=Dict();
+    for m in [$(join((m->"\"$m\"").(absentmodules),", "))];
+        modnames(m, top); 
+    end; 
+    serialize(STDOUT, top)"`)
+    
+    @async begin 
+        mods = deserialize(IOBuffer(read(o)))
+        for k in keys(mods)
+            if !(k in keys(server.cache))
+                info("added $k to cache")
+                server.cache[k] = mods[k]
+            end
+        end
+    end
 end
 
 function savecache(top)

--- a/src/languageserverinstance.jl
+++ b/src/languageserverinstance.jl
@@ -10,7 +10,8 @@ type LanguageServerInstance
     runlinter::Bool
 
     function LanguageServerInstance(pipe_in,pipe_out, debug_mode::Bool)
-        cache  = isfile(joinpath(Pkg.dir("LanguageServer"), "cache", "docs.cache")) ? loadcache() : Dict()
+        # cache  = isfile(joinpath(Pkg.dir("LanguageServer"), "cache", "docs.cache")) ? loadcache() : Dict()
+        cache = Dict()
 
         new(pipe_in,pipe_out,"", Dict{String,Document}(), cache, true, false)
     end

--- a/src/provider_completions.jl
+++ b/src/provider_completions.jl
@@ -46,14 +46,16 @@ function process(r::JSONRPC.Request{Val{Symbol("textDocument/completion")},TextD
                     push!(entries, (string(m), 9, "Module: $m"))
                     length(entries)>200 && break
                 end
-                for k in server.cache[m][:EXPORTEDNAMES]
-                    if startswith(string(k), word)
-                        if isa(server.cache[m][k], Dict)
-                            push!(entries, (string(k), 9, "Module: $k"))
-                            length(entries)>200 && break
-                        else
-                            push!(entries, (string(k), CompletionItemKind(server.cache[m][k][1]), server.cache[m][k][2]))
-                            length(entries)>200 && break
+                if m in keys(server.cache)
+                    for k in server.cache[m][:EXPORTEDNAMES]
+                        if startswith(string(k), word)
+                            if isa(server.cache[m][k], Dict)
+                                push!(entries, (string(k), 9, "Module: $k"))
+                                length(entries)>200 && break
+                            else
+                                push!(entries, (string(k), CompletionItemKind(server.cache[m][k][1]), server.cache[m][k][2]))
+                                length(entries)>200 && break
+                            end
                         end
                     end
                 end

--- a/src/provider_misc.jl
+++ b/src/provider_misc.jl
@@ -27,7 +27,7 @@ function process(r::JSONRPC.Request{Val{Symbol("initialize")},Dict{String,Any}},
     response = JSONRPC.Response(get(r.id), InitializeResult(serverCapabilities))
     send(response, server)
 
-    o,i, p = readandwrite(`julia -e "using LanguageServer;
+    o,i, p = readandwrite(`$JULIA_HOME/julia -e "using LanguageServer;
     top=Dict();
     LanguageServer.modnames(Main, top); 
     serialize(STDOUT, top)"`)

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -54,7 +54,7 @@ function get_cache_entry(word, server, modules=[])
         end
     else
         for m in allmod
-            if Symbol(word) in server.cache[m][:EXPORTEDNAMES]
+            if m in keys(server.cache) && Symbol(word) in server.cache[m][:EXPORTEDNAMES]
                 entry = server.cache[m][Symbol(word)]
             end
         end


### PR DESCRIPTION
This loads a child process for build the cache for `Main` and any references mods. There's some sort of conflict between the user's package directory and the LS one but  I can't quite pin down the problem yet.

I still want to get the `Base` caching faster so I'm going to look into transferring it submodule by submodule rather than as a single object