### PR TITLE
Move linter into separate process

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
 julia 0.5
 JSON 0.8.0
-Lint 0.2.5
+Lint 0.5.0
 URIParser 0.1.6

--- a/src/LanguageServer.jl
+++ b/src/LanguageServer.jl
@@ -1,7 +1,6 @@
 module LanguageServer
 
 using JSON
-using Lint
 using URIParser
 using JuliaParser
 

--- a/src/languageserverinstance.jl
+++ b/src/languageserverinstance.jl
@@ -17,7 +17,9 @@ type LanguageServerInstance
     function LanguageServerInstance(pipe_in,pipe_out, debug_mode::Bool, user_pkg_dir::AbstractString=haskey(ENV, "JULIA_PKGDIR") ? ENV["JULIA_PKGDIR"] : joinpath(homedir(),".julia"))
         cache = Dict()
 
-        new(pipe_in,pipe_out,"", Dict{String,Document}(), cache, Channel{Symbol}(128), debug_mode, false, user_pkg_dir, is_windows() ? "\\\\.\\pipe\\vscode-language-julia-lint-server-$(getpid())" : joinpath(tempname(), "vscode-language-julia-lint-server-$(getpid())"))
+        lint_pipe_name = is_windows() ? "\\\\.\\pipe\\vscode-language-julia-lint-server-$(getpid())" : joinpath(tempname(), "vscode-language-julia-lint-server-$(getpid())")
+
+        new(pipe_in,pipe_out,"", Dict{String,Document}(), cache, Channel{Symbol}(128), debug_mode, false, user_pkg_dir, lint_pipe_name)
     end
 end
 
@@ -43,7 +45,7 @@ function Base.run(server::LanguageServerInstance)
     env_new = copy(ENV)
     env_new["JULIA_PKGDIR"] = server.user_pkg_dir
 
-    lint_stdout,lint_stdin,lint_process = readandwrite(Cmd(`$JULIA_HOME/julia -e "Base.Sys.set_process_title(\"julia linter\"); using Lint; lintserver(\"$(server.lint_pipe_name)\");"`, env=env_new))
+    lint_stdout,lint_stdin,lint_process = readandwrite(Cmd(`$JULIA_HOME/julia -e "Base.Sys.set_process_title(\"julia linter\"); using Lint; lintserver(\"$(replace(server.lint_pipe_name, "\\", "\\\\"))\");"`, env=env_new))
 
     while true
         message = read_transport_layer(server.pipe_in, server.debug_mode)

--- a/src/languageserverinstance.jl
+++ b/src/languageserverinstance.jl
@@ -53,7 +53,7 @@ function Base.run(server::LanguageServerInstance)
     env_new = copy(ENV)
     env_new["JULIA_PKGDIR"] = server.user_pkg_dir
 
-    lint_stdout,lint_stdin,lint_process = readandwrite(Cmd(`$JULIA_HOME/julia -e "Base.Sys.set_process_title(\"julia linter\"); using Lint; lintserver(\"$(replace(server.lint_pipe_name, "\\", "\\\\"))\");"`, env=env_new))
+    lint_stdout,lint_stdin,lint_process = readandwrite(Cmd(`$JULIA_HOME/julia -e "Base.Sys.set_process_title(\"julia linter\"); using Lint; lintserver(\"$(replace(server.lint_pipe_name, "\\", "\\\\"))\", \"lint-message\");"`, env=env_new))
 
     while true
         message = read_transport_layer(server.pipe_in, server.debug_mode)

--- a/src/languageserverinstance.jl
+++ b/src/languageserverinstance.jl
@@ -19,7 +19,7 @@ type LanguageServerInstance
 
     diagnostic_requests::Channel{String}
 
-    function LanguageServerInstance(pipe_in,pipe_out, debug_mode::Bool, user_pkg_dir::AbstractString=haskey(ENV, "JULIA_PKGDIR") ? ENV["JULIA_PKGDIR"] : joinpath(homedir(),".julia"))
+    function LanguageServerInstance(pipe_in,pipe_out, debug_mode::Bool, user_pkg_dir::AbstractString=haskey(ENV, "JULIA_PKGDIR") ? ENV["JULIA_PKGDIR"] : joinpath(homedir(),".julia", "v$(VERSION.major).$(VERSION.minor)"))
         cache = Dict()
 
         lint_pipe_name = is_windows() ? "\\\\.\\pipe\\vscode-language-julia-lint-server-$(getpid())" : joinpath(tempname(), "vscode-language-julia-lint-server-$(getpid())")

--- a/src/languageserverinstance.jl
+++ b/src/languageserverinstance.jl
@@ -12,10 +12,12 @@ type LanguageServerInstance
 
     user_pkg_dir::String
 
+    lint_pipe_name::String
+
     function LanguageServerInstance(pipe_in,pipe_out, debug_mode::Bool, user_pkg_dir::AbstractString=haskey(ENV, "JULIA_PKGDIR") ? ENV["JULIA_PKGDIR"] : joinpath(homedir(),".julia"))
         cache = Dict()
 
-        new(pipe_in,pipe_out,"", Dict{String,Document}(), cache, Channel{Symbol}(128), debug_mode, false, user_pkg_dir)
+        new(pipe_in,pipe_out,"", Dict{String,Document}(), cache, Channel{Symbol}(128), debug_mode, false, user_pkg_dir, is_windows() ? "\\\\.\\pipe\\vscode-language-julia-lint-server-$(getpid())" : joinpath(tempname(), "vscode-language-julia-lint-server-$(getpid())"))
     end
 end
 
@@ -37,6 +39,11 @@ function Base.run(server::LanguageServerInstance)
             end
         end
     end
+
+    env_new = copy(ENV)
+    env_new["JULIA_PKGDIR"] = server.user_pkg_dir
+
+    lint_stdout,lint_stdin,lint_process = readandwrite(Cmd(`$JULIA_HOME/julia -e "Base.Sys.set_process_title(\"julia linter\"); using Lint; lintserver(\"$(server.lint_pipe_name)\");"`, env=env_new))
 
     while true
         message = read_transport_layer(server.pipe_in, server.debug_mode)

--- a/src/provider_diagnostics.jl
+++ b/src/provider_diagnostics.jl
@@ -1,31 +1,5 @@
 const LintSeverity = Dict('E'=>1,'W'=>2,'I'=>3)
 
 function process_diagnostics(uri::String, server::LanguageServerInstance)
-    document = get_text(server.documents[uri])
-
-    input = Dict("file"=>normpath(unescape(URI(uri).path))[2:end], "code_str"=>String(document))
-
-    @schedule begin
-        conn = connect(server.lint_pipe_name)
-
-        JSON.print(conn, input)
-
-        out = JSON.parse(conn)
-
-
-
-        diags = map(out) do l
-            line_number = l["line"]
-            start_col = findfirst(i->i!=' ', get_line(uri, line_number, server))
-            Diagnostic(Range(Position(line_number-1, start_col-1), Position(line_number-1, typemax(Int)) ),
-                        LintSeverity[string(l["code"])[1]],
-                        string(l["code"]),
-                        "Lint.jl",
-                        l["message"])
-        end
-        publishDiagnosticsParams = PublishDiagnosticsParams(uri, diags)
-
-        response =  JSONRPC.Request{Val{Symbol("textDocument/publishDiagnostics")},PublishDiagnosticsParams}(Nullable{Union{String,Int64}}(), publishDiagnosticsParams)
-        send(response, server)
-    end
+    put!(server.diagnostic_requests, uri)
 end

--- a/src/provider_diagnostics.jl
+++ b/src/provider_diagnostics.jl
@@ -2,17 +2,30 @@ const LintSeverity = Dict('E'=>1,'W'=>2,'I'=>3)
 
 function process_diagnostics(uri::String, server::LanguageServerInstance)
     document = get_text(server.documents[uri])
-    L = lintfile(normpath(unescape(URI(uri).path))[2:end], String(document))
-    diags = map(L) do l
-        start_col = findfirst(i->i!=' ', get_line(uri, l.line, server))
-        Diagnostic(Range(Position(l.line-1, start_col-1), Position(l.line-1, typemax(Int)) ),
-                        LintSeverity[string(l.code)[1]],
-                        string(l.code),
-                        "Lint.jl",
-                        l.message)
-    end
-    publishDiagnosticsParams = PublishDiagnosticsParams(uri, diags)
 
-    response =  JSONRPC.Request{Val{Symbol("textDocument/publishDiagnostics")},PublishDiagnosticsParams}(Nullable{Union{String,Int64}}(), publishDiagnosticsParams)
-    send(response, server)
+    input = Dict("file"=>normpath(unescape(URI(uri).path))[2:end], "code_str"=>String(document))
+
+    @schedule begin
+        conn = connect(server.lint_pipe_name)
+
+        JSON.print(conn, input)
+
+        out = JSON.parse(conn)
+
+
+
+        diags = map(out) do l
+            line_number = l["line"]
+            start_col = findfirst(i->i!=' ', get_line(uri, line_number, server))
+            Diagnostic(Range(Position(line_number-1, start_col-1), Position(line_number-1, typemax(Int)) ),
+                        LintSeverity[string(l["code"])[1]],
+                        string(l["code"]),
+                        "Lint.jl",
+                        l["message"])
+        end
+        publishDiagnosticsParams = PublishDiagnosticsParams(uri, diags)
+
+        response =  JSONRPC.Request{Val{Symbol("textDocument/publishDiagnostics")},PublishDiagnosticsParams}(Nullable{Union{String,Int64}}(), publishDiagnosticsParams)
+        send(response, server)
+    end
 end

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -80,6 +80,7 @@ function uri2filepath(uri::AbstractString)
 end
 
 function should_file_be_linted(uri, server)
+    !server.linter_is_installed && return false
     !server.runlinter && return false
 
     uri_path = uri2filepath(uri)


### PR DESCRIPTION
This is not perfect, but given that we want to kick out Lint.jl hopefully soon I think it might be good enough for now?

This no longer uses a Lint package that we bring with the VS extension, instead is requires Lint to be installed in the user pkg directory. I think that is the only way right now to have the lint process use the user precompiled binaries and also really isolate our LS process from any bugs/errors/problems in the lint process.