### PR TITLE
WorkspaceClientCapabilities constructor for empty capabilities

### DIFF
--- a/src/protocol/configuration.jl
+++ b/src/protocol/configuration.jl
@@ -33,6 +33,7 @@ function WorkspaceClientCapabilities(d::Dict)
     executeCommand = haskeynotnull(d, "executeCommand") ? Capabilities(d["executeCommand"]) : Capabilities()
     return WorkspaceClientCapabilities(applyEdit, workspaceEdit, didChangeConfiguration, didChangeWatchedFiles, symbol, executeCommand)
 end
+WorkspaceClientCapabilities() = WorkspaceClientCapabilities(Dict())
 
 type SynchroizationCapabilities
     dynamicRegistration::Bool


### PR DESCRIPTION
Add constructor when client provides an empty `workspace`

To support existing logic at [protocol/configuration.jl#L128](https://github.com/joshbode/LanguageServer.jl/blob/73865dad7a1c2d273266ae32c07bba9e9bcbbfdb/src/protocol/configuration.jl#L128).