### PR TITLE
transfer full doc text on change

### DIFF
--- a/src/provider_misc.jl
+++ b/src/provider_misc.jl
@@ -1,5 +1,5 @@
 const serverCapabilities = ServerCapabilities(
-                        TextDocumentSyncKind["Incremental"],
+                        TextDocumentSyncKind["Full"],
                         true, #hoverProvider
                         CompletionOptions(false, ["."]),
                         SignatureHelpOptions(["("]),
@@ -108,10 +108,11 @@ function process(r::JSONRPC.Request{Val{Symbol("textDocument/didChange")},DidCha
     doc = server.documents[r.params.textDocument.uri]
     doc._version = r.params.textDocument.version
     isempty(r.params.contentChanges) && return
-    dirty = get_offset(doc, last(r.params.contentChanges).range.start.line + 1, last(r.params.contentChanges).range.start.character + 1):get_offset(doc, first(r.params.contentChanges).range.stop.line + 1, first(r.params.contentChanges).range.stop.character + 1)
-    for c in r.params.contentChanges
-        update(doc, c.range.start.line + 1, c.range.start.character + 1, c.rangeLength, c.text)
-    end
+    # dirty = get_offset(doc, last(r.params.contentChanges).range.start.line + 1, last(r.params.contentChanges).range.start.character + 1):get_offset(doc, first(r.params.contentChanges).range.stop.line + 1, first(r.params.contentChanges).range.stop.character + 1)
+    # for c in r.params.contentChanges
+    #     update(doc, c.range.start.line + 1, c.range.start.character + 1, c.rangeLength, c.text)
+    # end
+    doc._content = last(r.params.contentChanges).text
     parse_all(doc, server)
 end
 

--- a/test/test_communication.jl
+++ b/test/test_communication.jl
@@ -17,7 +17,7 @@ init_response_json = JSON.parse("""
 {
     "id":0,"jsonrpc":"2.0",
     "result":{
-        "capabilities":{"textDocumentSync":2,
+        "capabilities":{"textDocumentSync":1,
                         "hoverProvider":true,
                         "completionProvider":{"resolveProvider":false,"triggerCharacters":["."]},
                         "signatureHelpProvider":{"triggerCharacters":["("]},


### PR DESCRIPTION
This should fix [this](https://github.com/JuliaEditorSupport/julia-vscode/issues/188), and incremental text update is not needed until incremental parsing returns