### PR TITLE
re-implement linter toggle

### DIFF
--- a/src/provider_diagnostics.jl
+++ b/src/provider_diagnostics.jl
@@ -11,13 +11,14 @@ function parse_all(doc, server)
     if ps.errored
         parse_errored(doc, ps)
     end
-    
-    if doc._runlinter
-        L = lint(doc, server)
-        append!(ps.diagnostics, L.diagnostics)
+    if server.runlinter
+        if doc._runlinter
+            L = lint(doc, server)
+            append!(ps.diagnostics, L.diagnostics)
+        end
+        
+        publish_diagnostics(doc, server)
     end
-    
-    publish_diagnostics(doc, server)
 end
 
 

--- a/test/test_lint.jl
+++ b/test/test_lint.jl
@@ -1,5 +1,5 @@
 server = LanguageServerInstance(IOBuffer(), IOBuffer(), true)
-
+server.runlinter = true
 function ≂(r1::LanguageServer.Range, r2::LanguageServer.Range)
     r1.start.line == r2.start.line &&
     r1.start.character == r2.start.character &&


### PR DESCRIPTION
Re-implements `Julia: Toggle Linter` command to switch on/off diagnostics (and thus formatting also)