### PR TITLE
fix symbols names in nested modules

### DIFF
--- a/src/lint.jl
+++ b/src/lint.jl
@@ -141,7 +141,7 @@ function lint(doc::Document, server)
     s = Scope(ScopePosition(uri, typemax(Int)), ScopePosition(last(path), 0), [], [], [], [], namespace, false, true, true, Diagnostic[])
     get_toplevel(server.documents[last(path)].code.ast, s, server)
     
-    current_namespace = isempty(s.namespace) ? :NOTHING : repack_dot(s.namespace)
+    current_namespace = isempty(s.namespace) ? :NOTHING : repack_dot(reverse(s.namespace))
     s.current = ScopePosition(uri)
 
     Lnames = Dict{Any,Int}()

--- a/src/scope.jl
+++ b/src/scope.jl
@@ -38,7 +38,7 @@ function get_scope(doc::Document, offset::Int, server)
     s.current = ScopePosition(uri)
     y = _find_scope(doc.code.ast, s, server)
 
-    current_namespace = isempty(s.namespace) ? :NOTHING : repack_dot(s.namespace)
+    current_namespace = isempty(s.namespace) ? :NOTHING : repack_dot(reverse(s.namespace))
     modules = collect_imports(s, server)
     
     return y, s, modules, current_namespace
@@ -133,17 +133,17 @@ function get_module(x::EXPR, s::Scope, server)
     get_toplevel(x.args[3], s_module, server)
     offset2 = s.current.offset + x.args[1].span + x.args[2].span
     for (v, loc, uri) in s_module.symbols
-        push!(s.symbols, (Variable(Expr(:(.), x.defs[1].id, QuoteNode(v.id)), v.t, v.val), loc, uri))
-        # if v.t == :IMPORTS
-        #     push!(s.symbols, (v, loc, uri))
-        # else
-        #     push!(s.symbols, (Variable(Expr(:(.), x.defs[1].id, QuoteNode(v.id)), v.t, v.val), loc, uri))
-        # end
+        # push!(s.symbols, (Variable(Expr(:(.), x.defs[1].id, QuoteNode(v.id)), v.t, v.val), loc, uri))
+        push!(s.symbols, (Variable(add_dot_prefix(x.defs[1].id, v.id), v.t, v.val), loc, uri))
     end
     # NEEDS FIX: 
     for impt in s_module.imports
         push!(s.imports, impt)
     end
+end
+
+function add_dot_prefix(prefix ,x)
+    repack_dot(vcat(prefix, unpack_dot(x)))
 end
 
 _find_scope(x::EXPR{T}, s::Scope, server) where T <: Union{IDENTIFIER,Quotenode,LITERAL} = x


### PR DESCRIPTION
This fixes the names of symbols defined within nested modules (noticed [here](https://github.com/ZacLN/CSTParser.jl/issues/18))