### PR TITLE
lint exports

### DIFF
--- a/src/trav/lint.jl
+++ b/src/trav/lint.jl
@@ -170,6 +170,26 @@ function lint(x::EXPR{T}, s::TopLevelScope, L::LintState, server, istop) where T
     #  NEEDS FIX: 
 end
 
+function lint(x::EXPR{CSTParser.Export}, s::TopLevelScope, L::LintState, server, istop)
+    offset = s.current.offset
+    exported_names = Set{String}()
+    for a in x.args
+        if a isa EXPR{IDENTIFIER}
+            loc = offset + (0:sizeof(x.val))
+            if a.val in exported_names
+                push!(L.diagnostics, CSTParser.Diagnostics.Diagnostic{CSTParser.Diagnostics.DuplicateArgument}(loc, [], "Variable $(x.val) is already exported"))
+            else
+                push!(exported_names, a.val)
+            end
+            nsEx = make_name(s.namespace, a.val)
+            if !haskey(s.symbols, nsEx)
+                push!(L.diagnostics, CSTParser.Diagnostics.Diagnostic{CSTParser.Diagnostics.PossibleTypo}(loc, [], "Variable $(x.val) is exported but not defined within the namespace"))
+            end
+        end
+        offset += a.span
+    end
+end
+
 function lint(x::EXPR{CSTParser.BinarySyntaxOpCall}, s::TopLevelScope, L::LintState, server, istop)
     if x.args[2] isa EXPR{CSTParser.OPERATOR{CSTParser.DotOp,Tokens.DOT,false}}
         # NEEDS FIX: check whether module or field of type


### PR DESCRIPTION
Checks for exporting of undefined variables, moves check of duplicated exports from CSTParser to LanguageServer