### PR TITLE
return cancel response on unknown uri request

### DIFF
--- a/src/provider_action.jl
+++ b/src/provider_action.jl
@@ -1,4 +1,8 @@
 function process(r::JSONRPC.Request{Val{Symbol("textDocument/codeAction")},CodeActionParams}, server)
+    if !haskey(server.documents, r.params.textDocument.uri)
+        send(JSONRPC.Response(get(r.id), CancelParams(get(r.id))), server)
+        return
+    end
     doc = server.documents[r.params.textDocument.uri]
     commands = Command[]
     range = r.params.range

--- a/src/provider_completions.jl
+++ b/src/provider_completions.jl
@@ -1,4 +1,8 @@
 function process(r::JSONRPC.Request{Val{Symbol("textDocument/completion")},TextDocumentPositionParams}, server)
+    if !haskey(server.documents, r.params.textDocument.uri)
+        send(JSONRPC.Response(get(r.id), CancelParams(get(r.id))), server)
+        return
+    end
     tdpp = r.params
     doc = server.documents[tdpp.textDocument.uri]
     offset = get_offset(doc, tdpp.position.line + 1, tdpp.position.character)

--- a/src/provider_definitions.jl
+++ b/src/provider_definitions.jl
@@ -1,4 +1,8 @@
 function process(r::JSONRPC.Request{Val{Symbol("textDocument/definition")},TextDocumentPositionParams}, server)
+    if !haskey(server.documents, r.params.textDocument.uri)
+        send(JSONRPC.Response(get(r.id), CancelParams(get(r.id))), server)
+        return
+    end
     tdpp = r.params
     doc = server.documents[tdpp.textDocument.uri]
     offset = get_offset(doc, tdpp.position.line + 1, tdpp.position.character + 1)

--- a/src/provider_formatting.jl
+++ b/src/provider_formatting.jl
@@ -1,4 +1,8 @@
 function process(r::JSONRPC.Request{Val{Symbol("textDocument/formatting")},DocumentFormattingParams}, server)
+    if !haskey(server.documents, r.params.textDocument.uri)
+        send(JSONRPC.Response(get(r.id), CancelParams(get(r.id))), server)
+        return
+    end
     doc = server.documents[r.params.textDocument.uri]
     edits = TextEdit[]
 

--- a/src/provider_hover.jl
+++ b/src/provider_hover.jl
@@ -1,4 +1,8 @@
 function process(r::JSONRPC.Request{Val{Symbol("textDocument/hover")},TextDocumentPositionParams}, server)
+    if !haskey(server.documents, r.params.textDocument.uri)
+        send(JSONRPC.Response(get(r.id), CancelParams(get(r.id))), server)
+        return
+    end
     tdpp = r.params
     doc = server.documents[tdpp.textDocument.uri]
     offset = get_offset(doc, tdpp.position.line + 1, tdpp.position.character)

--- a/src/provider_links.jl
+++ b/src/provider_links.jl
@@ -1,4 +1,8 @@
-function process(r::JSONRPC.Request{Val{Symbol("textDocument/documentLink")},DocumentLinkParams}, server) 
+function process(r::JSONRPC.Request{Val{Symbol("textDocument/documentLink")},DocumentLinkParams}, server)
+    if !haskey(server.documents, r.params.textDocument.uri)
+        send(JSONRPC.Response(get(r.id), CancelParams(get(r.id))), server)
+        return
+    end
     uri = r.params.textDocument.uri 
     doc = server.documents[uri]
     links = Tuple{String,UnitRange{Int}}[]

--- a/src/provider_references.jl
+++ b/src/provider_references.jl
@@ -5,6 +5,10 @@ mutable struct RefState
 end
 
 function process(r::JSONRPC.Request{Val{Symbol("textDocument/references")},ReferenceParams}, server)
+    if !haskey(server.documents, r.params.textDocument.uri)
+        send(JSONRPC.Response(get(r.id), CancelParams(get(r.id))), server)
+        return
+    end
     tdpp = r.params
     uri = tdpp.textDocument.uri
     doc = server.documents[tdpp.textDocument.uri]

--- a/src/provider_signatures.jl
+++ b/src/provider_signatures.jl
@@ -1,4 +1,8 @@
 function process(r::JSONRPC.Request{Val{Symbol("textDocument/signatureHelp")},TextDocumentPositionParams}, server)
+    if !haskey(server.documents, r.params.textDocument.uri)
+        send(JSONRPC.Response(get(r.id), CancelParams(get(r.id))), server)
+        return
+    end
     tdpp = r.params
     doc = server.documents[tdpp.textDocument.uri]
     word = get_word(tdpp, server)

--- a/src/provider_symbols.jl
+++ b/src/provider_symbols.jl
@@ -1,4 +1,8 @@
 function process(r::JSONRPC.Request{Val{Symbol("textDocument/documentSymbol")},DocumentSymbolParams}, server) 
+    if !haskey(server.documents, r.params.textDocument.uri)
+        send(JSONRPC.Response(get(r.id), CancelParams(get(r.id))), server)
+        return
+    end
     uri = r.params.textDocument.uri 
     doc = server.documents[uri]
     syms = SymbolInformation[]


### PR DESCRIPTION
Return empty response if `uri` in provider request can't be found