### PR TITLE
reparse files on change of git branch

### DIFF
--- a/src/provider_misc.jl
+++ b/src/provider_misc.jl
@@ -37,6 +37,13 @@ end
 
 
 function process(r::JSONRPC.Request{Val{Symbol("initialized")},Dict{String,Any}}, server) 
+    if isdir(joinpath(server.rootPath, ".git")) && isfile(joinpath(server.rootPath, ".git", "HEAD"))
+        @async begin
+            watch_file(joinpath(server.rootPath, ".git", "HEAD"))
+            
+            process(JSONRPC.Request{Val{:initialized},Dict{String,Any}}(Nullable{Int}(), Dict{String,Any}()), server)
+        end
+    end
     if server.rootPath != ""
         for (root, dirs, files) in walkdir(server.rootPath)
             for file in files


### PR DESCRIPTION
Who knew about `watch_file` ? 
This reparses/lints the workspace when you change branch. This seems to work but I don't know enough about git's internals to know if this is the best way to implement it