### PR TITLE
don't import `:.`

### DIFF
--- a/src/languageserverinstance.jl
+++ b/src/languageserverinstance.jl
@@ -28,7 +28,7 @@ function Base.run(server::LanguageServerInstance)
     wontload = []
     @schedule begin
         for (modname, uri, loc) in server.user_modules
-            if !(modname in wontload || modname in loaded) 
+            if !(modname in wontload || modname in loaded || modname == :.) 
                 try 
                     @eval import $modname
                     for (uri, doc) in server.documents


### PR DESCRIPTION
Fixes segfaults reported https://github.com/JuliaEditorSupport/julia-vscode/issues/236.
Sorry @davidanthoff, one more fix. Though I don't think this needs a new RC release: it's a one line change cutting out crashes!