### PR TITLE
script to launch LanguageServer

### DIFF
--- a/contrib/languageserver.sh
+++ b/contrib/languageserver.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+JULIABIN="julia"
+DEBUG="false"
+
+while [[ $# -gt 0 ]]
+    do
+    key="$1"
+
+    case $key in
+        -j|--julia)
+            JULIABIN="$2"
+            shift
+        ;;
+        --debug)
+            DEBUG="true"
+        ;;
+        *)
+            echo "unknown option: $key" >&2
+            exit
+        ;;
+    esac
+    shift
+done
+
+$JULIABIN --startup-file=no --history-file=no -e \
+    "using LanguageServer; server = LanguageServer.LanguageServerInstance(STDIN, STDOUT, $DEBUG); server.runlinter = true; run(server);" \
+    <&0 >&1 &
+
+PID=$!
+
+while true; do
+    # quit if server exited
+    kill -0 "$PID" || break
+    # if the current process is orphan, kill it and its children
+    if [ $(ps -o ppid= -p "$$") -eq 1 ]; then
+        kill -9 "$PID" $(pgrep -P "$PID")
+        exit
+    fi
+    sleep 1
+done


### PR DESCRIPTION
This is a script which I use in Sublime Text #166  to launch LanguageServer.

The reason of this is because Julia spawns a child process while precompiling packages and that childprocess makes julia so resistant so that julia won't be killed even the editor exits which leaves a orphan julia process. This script detects if the julia process is orphan and kill it and its possible child processes.

This script could be also used in other editors, e.g., emacs/neovim. Or even VSCode, not sure if VSCode is smart enough to kill all child processes.

It should also work on linux, though, I have only tested it on macOS. Also, not sure if Windows suffers from the same issue.