### PR TITLE
Fix STDERR redirection error

### DIFF
--- a/src/trav/toplevel.jl
+++ b/src/trav/toplevel.jl
@@ -133,8 +133,6 @@ function import_modules(x::Expr, server)
         if x.args[1] isa Symbol && x.args[1] != :. # julia issue 23173
             topmodname = x.args[1]
             if !isdefined(Main, topmodname)
-                oSTDERR = STDERR
-                redirect_stderr()
                 try 
                     @eval import $topmodname
                     server.loaded_modules[string(topmodname)] = load_mod_names(string(topmodname))
@@ -147,7 +145,6 @@ function import_modules(x::Expr, server)
                         end
                     end
                 end
-                redirect_stderr(oSTDERR)
             elseif !(string(topmodname) in keys(server.loaded_modules))
                 server.loaded_modules[string(topmodname)] = load_mod_names(string(topmodname))
             end


### PR DESCRIPTION
This fixes #185 on my system.

I don't think we need to redirect ``STDERR`` here, that is not used for the language server communication in any case.

We already redirect ``STDOUT`` [here](https://github.com/JuliaEditorSupport/julia-vscode/blob/master/scripts/languageserver/main.jl#L10), and I think that should be enough to prevent problems in the communication between the LS and vscode.