### PR TITLE
Remove lowercase calls for win paths

### DIFF
--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -179,8 +179,6 @@ function uri2filepath(uri::AbstractString)
         if uri_path[1] == '\\' || uri_path[1] == '/'
             uri_path = uri_path[2:end]
         end
-
-        uri_path = lowercase(uri_path)
     end
     return uri_path
 end
@@ -194,10 +192,6 @@ function should_file_be_linted(uri, server)
 
     uri_path = uri2filepath(uri)
     workspace_path = server.rootPath
-
-    if is_windows()
-        workspace_path = lowercase(workspace_path)
-    end
 
     if isempty(server.rootPath)
         return false


### PR DESCRIPTION
I think we should treat things as case sensitive on Windows, not like I did so far. That seems to be more in line with NTSF. This seems to at least move us in the right direction with respect to the path problems on Windows, not all the way yet, though...