### PR TITLE
Various filepath2uri fixes

### DIFF
--- a/src/provider_definitions.jl
+++ b/src/provider_definitions.jl
@@ -32,7 +32,7 @@ function process(r::JSONRPC.Request{Val{Symbol("textDocument/definition")},TextD
         if (file, m.line) == DefaultTypeConstructorLoc
             continue
         end
-        push!(locations, Location(is_windows() ? "file:///$(URIParser.escape(replace(file, '\\', '/')))" : "file:$(file)", Range(m.line - 1, 0, m.line, 0)))
+        push!(locations, Location(filepath2uri(file), Range(m.line - 1, 0, m.line, 0)))
     end
     
     

--- a/src/provider_diagnostics.jl
+++ b/src/provider_diagnostics.jl
@@ -39,8 +39,7 @@ end
 
 function update_includes(doc::Document, server::LanguageServerInstance)
     doc.code.includes = map(_get_includes(doc.code.ast)) do incl
-        (isabspath(incl[1]) ? filepath2uri(incl[1]) : joinpath(dirname(doc._uri), incl[1]), incl[2])
-        
+        (isabspath(incl[1]) ? filepath2uri(incl[1]) : joinuriwithpath(dirname(doc._uri), incl[1]), incl[2])
     end
 end
 

--- a/src/provider_misc.jl
+++ b/src/provider_misc.jl
@@ -58,7 +58,7 @@ function process(r::JSONRPC.Request{Val{Symbol("initialized")}}, server)
                     filepath = joinpath(root, file)
                     !isfile(filepath) && continue
                     info("parsed $filepath")
-                    uri = string("file://", is_windows() ? string("/", replace(replace(filepath, '\\', '/'), ":", "%3A")) : filepath)
+                    uri = filepath2uri(filepath)
                     content = readstring(filepath)
                     server.documents[uri] = Document(uri, content, true)
                     doc = server.documents[uri]
@@ -95,7 +95,7 @@ function process(r::JSONRPC.Request{Val{Symbol("textDocument/didOpen")},DidOpenT
     uri = r.params.textDocument.uri
     server.documents[uri] = Document(uri, r.params.textDocument.text, false)
     doc = server.documents[uri]
-    if startswith(uri, string("file://", server.rootPath))
+    if startswith(uri, filepath2uri(server.rootPath))
         doc._workspace_file = true
     end
     set_open_in_editor(doc, true)

--- a/src/provider_references.jl
+++ b/src/provider_references.jl
@@ -147,7 +147,7 @@ end
 function references(x::EXPR{Call}, s::TopLevelScope, L::LintState, R::RefState, server, istop)
     if isincludable(x)
         file = Expr(x.args[3])
-        file = isabspath(file) ? filepath2uri(file) : joinpath(dirname(s.current.uri), normpath(file))
+        file = isabspath(file) ? filepath2uri(file) : joinuriwithpath(dirname(s.current.uri), file)
         if file in keys(server.documents)
             oldpos = s.current
             s.current = ScopePosition(file, 0)

--- a/src/trav/lint.jl
+++ b/src/trav/lint.jl
@@ -280,7 +280,7 @@ function lint(x::EXPR{CSTParser.Call}, s::TopLevelScope, L::LintState, server, i
             push!(L.diagnostics, LSDiagnostic{PossibleTypo}(s.current.offset + (0:x.args[1].fullspan), [DocumentFormat.TextEdit(s.current.offset + (0:x.args[1].fullspan), "broadcast")], "Use of deprecated function"))
         elseif str_value(x.args[1]) == "include"
             file = str_value(x.args[3])
-            uri = isabspath(file) ? filepath2uri(file) : joinpath(dirname(s.current.uri), normpath(file))
+            uri = isabspath(file) ? filepath2uri(file) : joinuriwithpath(dirname(s.current.uri), file)
             if !(isincludable(x) && uri in keys(server.documents))
                 tws = CSTParser.trailing_ws_length(x)
                 push!(L.diagnostics, LSDiagnostic{PossibleTypo}(s.current.offset + (0:x.fullspan - tws), [], "Could not include $file"))

--- a/src/trav/local.jl
+++ b/src/trav/local.jl
@@ -248,7 +248,7 @@ function get_scope(x, s::TopLevelScope, server)
 
     if isincludable(x)
         file = Expr(x.args[3])
-        file = isabspath(file) ? filepath2uri(file) : joinpath(dirname(s.current.uri), normpath(file))
+        file = isabspath(file) ? filepath2uri(file) : joinuriwithpath(dirname(s.current.uri), file)
  
         file in s.path && return
  

--- a/src/trav/toplevel.jl
+++ b/src/trav/toplevel.jl
@@ -43,7 +43,7 @@ function toplevel(x, s::TopLevelScope, server)
             toplevel(a, s, server)
         elseif s.followincludes && isincludable(a)
             file = Expr(a.args[3])
-            uri = isabspath(file) ? filepath2uri(file) : joinpath(dirname(s.current.uri), normpath(file))
+            uri = isabspath(file) ? filepath2uri(file) : joinuriwithpath(dirname(s.current.uri), file)
 
             uri in s.path && return
             if uri in keys(server.documents)

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -184,7 +184,15 @@ function uri2filepath(uri::AbstractString)
 end
 
 function filepath2uri(file::String)
-    string("file://", normpath(file))
+    if is_windows()
+        file = normpath(file)
+        file = replace(file, "\\", "/")
+        file = escape(file)
+        file = replace(file, "%2F", "/")
+        return string("file:///", file)
+    else
+        return string("file://", normpath(file))
+    end
 end
 
 function should_file_be_linted(uri, server)

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -195,6 +195,12 @@ function filepath2uri(file::String)
     end
 end
 
+function joinuriwithpath(uri::AbstractString, path::AbstractString)
+    left_file_path = uri2filepath(uri)
+    combined_path = joinpath(left_file_path, path)
+    return filepath2uri(combined_path)
+end
+
 function should_file_be_linted(uri, server)
     !server.runlinter && return false
 


### PR DESCRIPTION
This a) fixes ``filepath2uri`` on win and b) uses that function in various places where I think it should be used.

I also added a ``joinuriwithpath`` function that does that correctly on Windows and use that where it should be used.