### PR TITLE
Remove rootPath from LS

### DIFF
--- a/src/languageserverinstance.jl
+++ b/src/languageserverinstance.jl
@@ -2,7 +2,6 @@ mutable struct LanguageServerInstance
     pipe_in
     pipe_out
 
-    rootPath::String 
     workspaceFolders::Set{String}
     documents::Dict{URI2,Document}
 
@@ -18,7 +17,7 @@ mutable struct LanguageServerInstance
         loaded_modules["Base"] = load_mod_names(Base)
         loaded_modules["Core"] = load_mod_names(Core)
 
-        new(pipe_in, pipe_out, "", Set{String}(), Dict{URI2,Document}(), loaded_modules, debug_mode, false, false, user_pkg_dir)
+        new(pipe_in, pipe_out, Set{String}(), Dict{URI2,Document}(), loaded_modules, debug_mode, false, false, user_pkg_dir)
     end
 end
 

--- a/src/provider_misc.jl
+++ b/src/provider_misc.jl
@@ -20,15 +20,17 @@ const serverCapabilities = ServerCapabilities(
                         true)
 
 function process(r::JSONRPC.Request{Val{Symbol("initialize")},InitializeParams}, server)
-    if !isnull(r.params.rootUri)
-        server.rootPath = uri2filepath(r.params.rootUri.value)
-    elseif !isnull(r.params.rootPath)
-        server.rootPath = r.params.rootPath.value
+    # Only look at rootUri and rootPath if the client doesn't support workspaceFolders
+    if isnull(r.params.capabilities.workspace.workspaceFolders) || get(r.params.capabilities.workspace.workspaceFolders)==false
+        if !isnull(r.params.rootUri)
+            push!(server.workspaceFolders, uri2filepath(r.params.rootUri.value))
+        elseif !isnull(r.params.rootPath)
+            push!(server.workspaceFolders,  r.params.rootPath.value)
+        end
     else
-        server.rootPath = ""
-    end
-    for wksp in r.params.workspaceFolders
-        push!(server.workspaceFolders, uri2filepath(wksp.uri))
+        for wksp in r.params.workspaceFolders
+            push!(server.workspaceFolders, uri2filepath(wksp.uri))
+        end
     end
     
     response = JSONRPC.Response(get(r.id), InitializeResult(serverCapabilities))
@@ -99,7 +101,6 @@ function process(r::JSONRPC.Request{Val{Symbol("initialized")}}, server)
     #         end
     #     end
     # end
-    load_folder(server.rootPath, server)
     info(server.workspaceFolders)
     for wkspc in server.workspaceFolders
         load_folder(wkspc, server)
@@ -130,7 +131,7 @@ function process(r::JSONRPC.Request{Val{Symbol("textDocument/didOpen")},DidOpenT
     uri = r.params.textDocument.uri
     server.documents[URI2(uri)] = Document(uri, r.params.textDocument.text, false)
     doc = server.documents[URI2(uri)]
-    if startswith(uri, filepath2uri(server.rootPath))
+    if any(i->startswith(uri, filepath2uri(i)), server.workspaceFolders)
         doc._workspace_file = true
     end
     set_open_in_editor(doc, true)
@@ -329,20 +330,20 @@ function JSONRPC.parse_params(::Type{Val{Symbol("julia/lint-package")}}, params)
 end
 
 
-function get_REQUIRE(server)
-    str = readlines(joinpath(server.rootPath, "REQUIRE"))
-    req = Tuple{Symbol,VersionNumber}[]
+# function get_REQUIRE(server)
+#     str = readlines(joinpath(server.rootPath, "REQUIRE"))
+#     req = Tuple{Symbol,VersionNumber}[]
     
-    for line in str
-        m = (split(line, " "))
-        if length(m) == 2
-            push!(req, (Symbol(m[1]), VersionNumber(m[2])))
-        else
-            push!(req, (Symbol(m[1]), VersionNumber(0)))
-        end
-    end
-    return req
-end
+#     for line in str
+#         m = (split(line, " "))
+#         if length(m) == 2
+#             push!(req, (Symbol(m[1]), VersionNumber(m[2])))
+#         else
+#             push!(req, (Symbol(m[1]), VersionNumber(0)))
+#         end
+#     end
+#     return req
+# end
 
 
 function process(r::JSONRPC.Request{Val{Symbol("julia/toggle-lint")},TextDocumentIdentifier}, server)

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -208,12 +208,11 @@ function should_file_be_linted(uri, server)
     !server.runlinter && return false
 
     uri_path = uri2filepath(uri)
-    workspace_path = server.rootPath
 
-    if isempty(server.rootPath)
+    if length(server.workspaceFolders)==0
         return false
     else
-        return startswith(uri_path, workspace_path)
+        return any(i->startswith(uri_path, i), server.workspaceFolders)
     end
 end
 


### PR DESCRIPTION
I think we should just entirely remove the ``rootPath`` field from our internal design. Even when we have a client that doesn't support multi root, we can just handle that as a multi-root situation with only one entry in ``workspaceFolders``.

@ZacLN This PR would merge things into the branch ``wkspflds``. I might have another PR coming in the same manner. Once we have everything sorted out on ``wkspflds``, we can then merge it into ``master``.