### PR TITLE
Use correct server capabilities form

### DIFF
--- a/src/protocol/configuration.jl
+++ b/src/protocol/configuration.jl
@@ -198,6 +198,15 @@ mutable struct TextDocumentSyncOptions
     save::SaveOptions
 end
 
+mutable struct WorkspaceFoldersOptions
+    supported::Bool
+    changeNotifications::Union{Bool,String}
+end
+
+mutable struct WorkspaceOptions
+    workspaceFolders::WorkspaceFoldersOptions
+end
+
 mutable struct ServerCapabilities
     textDocumentSync::Int
     hoverProvider::Bool
@@ -217,7 +226,7 @@ mutable struct ServerCapabilities
     documentLinkProvider::DocumentLinkOptions
     executeCommandProvider::ExecuteCommandOptions
     experimental
-    workspaceFolders::Bool
+    workspace::WorkspaceOptions
 end
 
 mutable struct InitializeResult

--- a/src/provider_misc.jl
+++ b/src/provider_misc.jl
@@ -17,7 +17,7 @@ const serverCapabilities = ServerCapabilities(
                         DocumentLinkOptions(false),
                         ExecuteCommandOptions(),
                         nothing,
-                        true)
+                        WorkspaceOptions(WorkspaceFoldersOptions(true, true)))
 
 function process(r::JSONRPC.Request{Val{Symbol("initialize")},InitializeParams}, server)
     if !isnull(r.params.rootUri)

--- a/test/test_communication.jl
+++ b/test/test_communication.jl
@@ -33,7 +33,12 @@ init_response_json = JSON.parse("""
                         "documentLinkProvider":{"resolveProvider":false},
                         "executeCommandProvider":{"commands":[]},
                         "experimental":null,
-                        "workspaceFolders":true
+                        "workspace":{
+                            "workspaceFolders": {
+                                "supported":true,
+                                "changeNotifications":true
+                            }
+                        }
                     }
             }
 }


### PR DESCRIPTION
This is how I interpret the [spec](https://github.com/Microsoft/vscode-languageserver-node/blob/master/protocol/src/protocol.workspaceFolders.proposed.md) and what we should do. But for some reason that also doesn't seem enough to trigger the workspace change notifications. I'm waiting for some feedback on the VS Code slack right now, but maybe we can merge this in the meantime, it does seem slightly more in line with the spec than the previous iteration?