### PR TITLE
Fixed loading SymbolServer, as referenced in issue 300

### DIFF
--- a/src/languageserverinstance.jl
+++ b/src/languageserverinstance.jl
@@ -15,7 +15,7 @@ mutable struct LanguageServerInstance
     packages::Dict
     env_path::String
     depot_path::String
-    symbol_server::Union{Nothing,StaticLint.SymbolServer.SymbolServerProcess}
+    symbol_server::Union{Nothing,SymbolServer.SymbolServerProcess}
 
     function LanguageServerInstance(pipe_in, pipe_out, debug_mode::Bool, env_path, depot_path, packages)
         new(pipe_in, pipe_out, Set{String}(), Dict{URI2,Document}(),  debug_mode, false, Set{String}(), false, packages, env_path, depot_path, nothing)


### PR DESCRIPTION
I was having issues precompiling and using the LS since it was complaining about SymbolServer not being found. This fixes the error for me.