### PR TITLE
Fix #340

### DIFF
--- a/src/protocol/document.jl
+++ b/src/protocol/document.jl
@@ -90,7 +90,7 @@ mutable struct DidChangeWatchedFilesRegistrationOptions
     watchers::Vector{FileSystemWatcher}
 end
 
-mutable struct WillSaveTextDocumentParams
+@json_read mutable struct WillSaveTextDocumentParams
     textDocument::TextDocumentIdentifier
     reason::Int
 end


### PR DESCRIPTION
I don't see any way that *any* textDocument/willSave request could have been handled by this server before. I'm guessing VS Code doesn't make use of this functionality? In any case, this keeps the server from crashing; not sure if the server actually does anything with this request; didn't quite grok the code enough for that. Let me know if any problems.

Closes #340.